### PR TITLE
Revert "Double font sizes in presentation mode [Closes #50830269]"

### DIFF
--- a/app/assets/stylesheets/deck.scss
+++ b/app/assets/stylesheets/deck.scss
@@ -16,14 +16,6 @@ i {
   line-height: 28px;
 }
 
-.slide h1 {
-  font-size: 9em !important;
-}
-
-.slide ul {
-  font-size: 200% !important;
-}
-
 .ui-tooltip {
   font-size: 16px !important;
 }


### PR DESCRIPTION
This reverts commit afbedcae779d53144d8c28d474def008e2a13667.

These rules were making `<h1>` and `<ul>` elements extremely large.

Fixes #91